### PR TITLE
Render triangle using vertex buffer

### DIFF
--- a/main.mojo
+++ b/main.mojo
@@ -1,9 +1,27 @@
 import wgpu
-from wgpu import glfw
+from wgpu import glfw, VertexAttribute, VertexFormat, Color, VertexBufferLayout, BufferUsage, BufferDescriptor, VertexStepMode
+from sys.info import sizeof
 
 from memory import Span
 from collections import Optional
 
+@value
+struct Vec3:
+    var x: Float32
+    var y: Float32
+    var z: Float32
+
+@value
+struct MyColor:
+    var r: Float32
+    var g: Float32
+    var b: Float32
+    var a: Float32
+
+@value
+struct MyVertex:
+    var pos: Vec3
+    var color: MyColor
 
 def main():
     glfw.init()
@@ -31,33 +49,44 @@ def main():
     )
 
     shader_code = """
+        struct VertexOutput {
+            @builtin(position) position: vec4<f32>,
+            @location(1) color: vec4<f32>,
+        };
+
         @vertex
-        fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> @builtin(position) vec4<f32> {
-           	var p = vec2<f32>(0.0, 0.0);
-           	if (in_vertex_index == 0u) {
-          		p = vec2<f32>(-0.5, -0.5);
-           	} else if (in_vertex_index == 1u) {
-          		p = vec2<f32>(0.5, -0.5);
-           	} else {
-          		p = vec2<f32>(0.0, 0.5);
-           	}
-           	return vec4<f32>(p, 0.0, 1.0);
+        fn vs_main(@location(0) in_pos: vec3<f32>, @location(1) in_color: vec4<f32>) -> VertexOutput {
+            var p = in_pos;
+            return VertexOutput(vec4<f32>(p, 1.0), in_color);
         }
 
         @fragment
-        fn fs_main() -> @location(0) vec4<f32> {
-           	return vec4<f32>(0.0, 0.4, 1.0, 1.0);
+        fn fs_main(@location(1) in_color: vec4<f32>) -> @location(0) vec4<f32> {
+            // Convert color from u32 to f32
+            //let color = vec4<f32>(f32(in_color.x) / 255.0, f32(in_color.y) / 255.0, f32(in_color.z) / 255.0, f32(in_color.w) / 255.0);
+            return in_color;
         }
         """
 
     shader_module = device.create_wgsl_shader_module(code=shader_code)
+
+    vertex_attributes = List[VertexAttribute](
+        VertexAttribute(format=VertexFormat.float32x3, offset=0, shader_location=0),
+        VertexAttribute(format=VertexFormat.float32x4, offset=sizeof[Vec3](), shader_location=1)
+    )
+
+    vertex_buffer_layout = VertexBufferLayout[StaticConstantOrigin](
+        array_stride=sizeof[MyVertex](),
+        step_mode=VertexStepMode.vertex,
+        attributes=Span[VertexAttribute, StaticConstantOrigin](ptr=vertex_attributes.unsafe_ptr(), length=len(vertex_attributes))
+    )
 
     desc = wgpu.RenderPipelineDescriptor(
         label="render pipeline",
         vertex=wgpu.VertexState(
             entry_point="vs_main",
             module=shader_module,
-            buffers=List[wgpu.VertexBufferLayout[StaticConstantOrigin]](),
+            buffers=List[VertexBufferLayout[StaticConstantOrigin]](vertex_buffer_layout),
         ),
         fragment=wgpu.FragmentState(
             module=shader_module,
@@ -92,6 +121,23 @@ def main():
     )
     pipeline = device.create_render_pipeline(descriptor=desc)
 
+    vertices = List[MyVertex](
+        MyVertex(Vec3(-0.5, -0.5, 0.0), MyColor(1, 0, 0, 1)),
+        MyVertex(Vec3(0.5, -0.5, 0.0), MyColor(0, 1, 0, 1)),
+        MyVertex(Vec3(0.0, 0.5, 0.0), MyColor(0, 0, 1, 1))
+    )
+    vertices_size_bytes = len(vertices) * sizeof[MyVertex]()
+    vertex_buffer = device.create_buffer(BufferDescriptor(
+        "vertex buffer",
+        BufferUsage.vertex,
+        vertices_size_bytes,
+        True
+    ))
+    dst = vertex_buffer.get_mapped_range(0, vertices_size_bytes).bitcast[MyVertex]()
+    for i in range(len(vertices)):
+        dst[i] = vertices[i]
+    vertex_buffer.unmap()
+
     while not window.should_close():
         glfw.poll_events()
         with surface.get_current_texture() as surface_tex:
@@ -121,6 +167,7 @@ def main():
 
             rp = encoder.begin_render_pass(color_attachments=color_attachments)
             rp.set_pipeline(pipeline)
+            rp.set_vertex_buffer(0, 0, vertex_buffer.get_size(), vertex_buffer)
             rp.draw(3, 1, 0, 0)
             rp.end()
 

--- a/wgpu/objects.mojo
+++ b/wgpu/objects.mojo
@@ -188,15 +188,19 @@ struct Buffer:
     #         ) -> None
     #     ]("wgpuBufferMapAsync")(handle, mode, offset, size, callback, user_data)
 
-    # fn buffer_get_mapped_range(
-    #     handle: WGPUBuffer, offset: UInt, size: UInt
-    # ) -> UnsafePointer[NoneType]:
-    #     """
-    #     TODO
-    #     """
-    #     return _wgpu.get_function[
-    #         fn (WGPUBuffer, UInt, UInt) -> UnsafePointer[NoneType]
-    #     ]("wgpuBufferGetMappedRange")(handle, offset, size)
+    fn get_mapped_range(
+        self,
+        offset: UInt,
+        size: UInt
+    ) -> UnsafePointer[NoneType]:
+        """
+        TODO
+        """
+        return _c.buffer_get_mapped_range(
+            self._handle,
+            offset,
+            size
+        )
 
     # fn buffer_get_const_mapped_range(
     #     handle: WGPUBuffer, offset: UInt, size: UInt
@@ -1866,21 +1870,23 @@ struct RenderPassEncoder:
     #         fn (WGPURenderPassEncoder, UInt32, UInt32, UInt32, UInt32) -> None
     #     ]("wgpuRenderPassEncoderSetScissorRect")(handle, x, y, width, height)
 
-    # fn render_pass_encoder_set_vertex_buffer(
-    #     handle: WGPURenderPassEncoder,
-    #     slot: UInt32,
-    #     offset: UInt64,
-    #     size: UInt64,
-    #     buffer: WGPUBuffer = WGPUBuffer(),
-    # ) -> None:
-    #     """
-    #     TODO
-    #     """
-    #     return _wgpu.get_function[
-    #         fn (WGPURenderPassEncoder, UInt32, WGPUBuffer, UInt64, UInt64) -> None
-    #     ]("wgpuRenderPassEncoderSetVertexBuffer")(
-    #         handle, slot, buffer, offset, size
-    #     )
+    fn set_vertex_buffer(
+        self,
+        slot: UInt32,
+        offset: UInt64,
+        size: UInt64,
+        buffer: Buffer
+    ):
+        """
+        TODO
+        """
+        _c.render_pass_encoder_set_vertex_buffer(
+            self._handle,
+            slot,
+            offset,
+            size,
+            buffer._handle
+        )
 
     # fn render_pass_encoder_set_index_buffer(
     #     handle: WGPURenderPassEncoder,


### PR DESCRIPTION
Hi, I'm trying to set vertex buffer but I get this when I run:
```
RUST_BACKTRACE=full magic run exec
1
thread '<unnamed>' panicked at src/lib.rs:2162:34:
invalid vertex step mode for vertex buffer layout
stack backtrace:
   0:        0x10eb49338 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h41035ce174e31160
   1:        0x10eb64150 - core::fmt::write::h7e946826fce7616b
   2:        0x10eb4775c - std::io::Write::write_fmt::he3645adfefb23e4a
   3:        0x10eb49190 - std::sys_common::backtrace::print::h2efe9ae66fda73dc
   4:        0x10eb4a368 - std::panicking::default_hook::{{closure}}::hd27200b4fbd3bf40
   5:        0x10eb4a034 - std::panicking::default_hook::hb8656334461229c8
   6:        0x10eb4ac14 - std::panicking::rust_panic_with_hook::h10171cf76e1aed15
   7:        0x10eb4a624 - std::panicking::begin_panic_handler::{{closure}}::h9344de43a47cae21
   8:        0x10eb497bc - std::sys_common::backtrace::__rust_end_short_backtrace::h55013ada3ab9c4e8
   9:        0x10eb4a3c0 - _rust_begin_unwind
  10:        0x10eb96878 - core::panicking::panic_fmt::h0b16bb09366e1f01
  11:        0x10e6c4148 - <alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter::h87a600cf9ed7de3a
  12:        0x10e75ae5c - _wgpuDeviceCreateRenderPipeline
fatal runtime error: failed to initiate panic, error 5
Please submit a bug report to https://github.com/modularml/mojo/issues and include the crash backtrace along with all the relevant source codes.
Stack dump:
0.      Program arguments: /Users/jehanlos/Documents/wgpu-mojo/.magic/envs/default/bin/mojo main.mojo
mojo crashed!
Please file a bug report.
[42138:1675564:20250120,130028.457762:WARNING in_range_cast.h:38] value -634136515 out of range
[42138:1675564:20250120,130028.467262:WARNING crash_report_exception_handler.cc:257] UniversalExceptionRaise: (os/kern) failure (5)
```
I get this in create_render_pipeline when passing a vertex_buffer_layout. The two clues I see are
```
invalid vertex step mode for vertex buffer layout
```
even though I'm passing 0 which is a [valid VertexStepMode](https://docs.rs/wgpu/latest/wgpu/enum.VertexStepMode.html) (I tried 1 as well just to see if I could get it past create_render_pipeline) and
```
<alloc::vec::Vec<T> as alloc::vec::spec_from_iter::SpecFromIter<T,I>>::from_iter::h87a600cf9ed7de3a
```
only happens when passing a vertex buffer layout. It seems to me like it could possibly be an alignment issue with WGPUVertexBufferLayout during marshalling. Does Mojo offer control of struct field byte alignment? I searched and could not find any way to do so.